### PR TITLE
Fix passed `PACKAGE_VERSION` variable

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -38,7 +38,7 @@ jobs:
                 echo $PATH
                 ls -l ~/.julia/bin
                 mkdir results
-                benchpkg ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.repository.default_branch}}" --output-dir=results/
+                benchpkg ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.repository.default_branch}}" --output-dir=results/ --tune
             - name: Create plots from benchmarks
               run: |
                 mkdir -p plots

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AirspeedVelocity"
 uuid = "1c8270ee-6884-45cc-9545-60fa71ec23e4"
 authors = ["Miles Cranmer <miles.cranmer@gmail.com>"]
-version = "0.3.1"
+version = "0.4.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -133,7 +133,20 @@ function _benchmark(
 
         # Safely include, via module:
         module AirspeedVelocityRunner
-            const PACKAGE_VERSION = $(spec.rev)
+            import $(Symbol(spec.name)): $(Symbol(spec.name)) as _AirspeedVelocityTestImport
+            import TOML: parsefile as toml_parsefile
+            const PACKAGE_VERSION = let
+                try
+                    project = toml_parsefile(
+                        joinpath(pkgdir(_AirspeedVelocityTestImport), "Project.toml"),
+                    )
+                    VersionNumber(project["version"])
+                catch
+                    VersionNumber("0.0.0")
+                end
+            end
+
+            # Included benchmark script:
             include($script)
         end
 

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -133,15 +133,16 @@ function _benchmark(
 
         # Safely include, via module:
         module AirspeedVelocityRunner
-            import $(Symbol(spec.name)): $(Symbol(spec.name)) as _AirspeedVelocityTestImport
+            import $(Symbol(spec.name)): $(Symbol(spec.name)) as _AirspeedVelocityTestImport2
             import TOML: parsefile as toml_parsefile
             const PACKAGE_VERSION = let
                 try
                     project = toml_parsefile(
-                        joinpath(pkgdir(_AirspeedVelocityTestImport), "Project.toml"),
+                        joinpath(pkgdir(_AirspeedVelocityTestImport2), "Project.toml"),
                     )
                     VersionNumber(project["version"])
                 catch
+                    @warn "Failed to create `PACKAGE_VERSION`"
                     VersionNumber("0.0.0")
                 end
             end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -106,7 +106,7 @@ function _benchmark(
     @info "    Adding packages."
     # Filter out empty strings from extra_pkgs:
     extra_pkgs = filter(x -> x != "", extra_pkgs)
-    pkgs = ["BenchmarkTools", "JSON3", "Pkg", extra_pkgs...]
+    pkgs = ["BenchmarkTools", "JSON3", "Pkg", "TOML", extra_pkgs...]
     Pkg.add([spec, [PackageSpec(; name=pkg) for pkg in pkgs]...]; io=devnull)
     Pkg.precompile()
     Pkg.activate(old_project; io=devnull)

--- a/test/test_benchmark.jl
+++ b/test/test_benchmark.jl
@@ -17,6 +17,8 @@ end
         using BenchmarkTools
         using SymbolicRegression
 
+        @assert PACKAGE_VERSION in (v"0.15.3", v"0.16.2")
+
         const SUITE = BenchmarkGroup()
         SUITE["eval_tree_array"] = begin
             b = BenchmarkGroup()
@@ -54,7 +56,7 @@ end
     tmp2 = mktempdir(; cleanup=false)
     script = joinpath(tmp2, "bench.jl")
     open(script, "w") do io
-        print(io, """
+        write(io, """
             using BenchmarkTools
             using Transducers
 


### PR DESCRIPTION
This makes the `PACKAGE_VERSION` passed to the benchmark script actually equal to the version, rather than the git SHA which it was before this change.

@Krastanov would you be up for a quick review?