### PR TITLE
Add FakeExample package for testing use manifest functionality

### DIFF
--- a/test/FakeExample/Project.toml
+++ b/test/FakeExample/Project.toml
@@ -1,0 +1,3 @@
+name = "Example"
+uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+version = "0.5.4"

--- a/test/FakeExample/src/Example.jl
+++ b/test/FakeExample/src/Example.jl
@@ -1,0 +1,5 @@
+module Example
+
+ManifestTestPkg() = true
+
+end


### PR DESCRIPTION
I think this needs to be merged before #22, if we want #22 to use this package in testing.