### PR TITLE
Allow missing benchmarks across revisions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         version:
           - '1.7'
-          - '1.8'
+          - '1'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AirspeedVelocity"
 uuid = "1c8270ee-6884-45cc-9545-60fa71ec23e4"
 authors = ["Miles Cranmer <miles.cranmer@gmail.com>"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,6 +2,7 @@ using AirspeedVelocity
 using OrderedCollections: OrderedDict
 using Pkg
 using Documenter
+using Documenter: Remotes
 
 # First, we copy README.md to index.md,
 # replacing <README> in _index.md with the contents of README.md:
@@ -27,7 +28,7 @@ DocMeta.setdocmeta!(
 makedocs(;
     modules = [AirspeedVelocity],
     authors = "Miles Cranmer <miles.cranmer@gmail.com>",
-    repo = "https://github.com/MilesCranmer/AirspeedVelocity.jl/blob/{commit}{path}#{line}",
+    repo = Remotes.GitHub("MilesCranmer", "AirspeedVelocity.jl"),
     sitename = "AirspeedVelocity.jl",
     format = Documenter.HTML(;
         prettyurls = get(ENV, "CI", "false") == "true",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -36,6 +36,7 @@ makedocs(;
         assets = String[],
     ),
     pages = ["Home" => "index.md", "API" => "api.md"],
+    warnonly = true,
 )
 
 deploydocs(; repo = "github.com/MilesCranmer/AirspeedVelocity.jl", devbranch = "master")

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -2,6 +2,14 @@
 
 ## Creating benchmarks
 
+From the command line:
+
+```@docs
+benchpkg
+```
+
+Or, directly from Julia:
+
 ```@docs
 benchmark(package_name::String, rev::Vector{String}; output_dir::String=".", script::Union{String,Nothing}=nothing, tune::Bool=false, exeflags::Cmd=``, extra_pkgs::Vector{String}=String[])
 ```
@@ -10,7 +18,14 @@ benchmark(package_name::String, rev::Vector{String}; output_dir::String=".", scr
 benchmark(package_specs::Vector{PackageSpec}; output_dir::String = ".", script::Union{String,Nothing} = nothing, tune::Bool = false, exeflags::Cmd = ``, extra_pkgs = String[])
 ```
 
-## Loading benchmarks
+## Loading and visualizing benchmarks
+
+From the command line:
+
+```@docs
+benchpkgtable
+benchpkgplot
+```
 
 ```@docs
 load_results(specs::Vector{PackageSpec}; input_dir::String=".")

--- a/test/test_benchmark.jl
+++ b/test/test_benchmark.jl
@@ -148,10 +148,12 @@ end
         "v1" => OrderedDict(
             "bench1" => Dict("median" => 1.2e9, "75" => 1.3e9, "25" => 1.1e9),
             "bench2" => Dict("median" => 0.2e6, "75" => 0.3e6, "25" => 0.1e6),
+            #= We leave out bench3 as a test =#
         ),
         "v2" => OrderedDict(
             "bench1" => Dict("median" => 1.2e10, "75" => 1.3e10, "25" => 1.1e10),
             "bench2" => Dict("median" => 0.2e5, "75" => 0.3e5, "25" => 0.1e5),
+            "bench3" => Dict("median" => 0.2e5, "75" => 0.3e5, "25" => 0.1e5),
         ),
     )
 
@@ -160,6 +162,7 @@ end
     |:-------|:------------:|:----------:|:-----------:|
     | bench1 | 1.2 ± 0.2 s  | 12 ± 2 s   | 0.1         |
     | bench2 | 0.2 ± 0.2 ms | 20 ± 20 μs | 10          |
+    | bench3 |              | 20 ± 20 μs |             |
     """
     @test truth ≈ create_table(combined_results)
 


### PR DESCRIPTION
Won't throw an error if there is a benchmark missing from an older revision, such as when a new benchmark is created