### PR TITLE
Support `dirty` revision

### DIFF
--- a/src/BenchPkg.jl
+++ b/src/BenchPkg.jl
@@ -18,7 +18,8 @@ Benchmark a package over a set of revisions.
 
 # Options
 
-- `-r, --rev <arg>`: Revisions to test (delimit by comma).
+- `-r, --rev <arg>`: Revisions to test (delimit by comma). Use `dirty` to
+  benchmark the current state of the package at `path` (and not a git commit).
 - `-o, --output-dir <arg>`: Where to save the JSON results.
 - `-s, --script <arg>`: The benchmark script. Default: `benchmark/benchmarks.jl` downloaded from `stable`.
 - `-e, --exeflags <arg>`: CLI flags for Julia (default: none).

--- a/test/test_benchmark.jl
+++ b/test/test_benchmark.jl
@@ -243,7 +243,7 @@ end
     cd(tmp_dir)
     Pkg.generate("TestPackage")
     path = joinpath(tmp_dir, "TestPackage")
-    run(`git -C $path init`)
+    run(`git -C "$path" init`)
     # write benchmarks.jl in the package:
     script = joinpath(path, "bench.jl")
     open(joinpath(script), "w") do io

--- a/test/test_benchmark.jl
+++ b/test/test_benchmark.jl
@@ -1,6 +1,7 @@
 using AirspeedVelocity
 using OrderedCollections: OrderedDict
 using Test
+using Pkg
 import Base: isapprox
 
 function Base.isapprox(s1::String, s2::String)
@@ -116,7 +117,7 @@ end
 
     const SUITE = BenchmarkGroup()
 
-    problems =  [   
+    problems =  [
                     "constant_fix!_with_complex_numbers",
                     "affine_dot_multiply_atom",
                     "affine_hcat_atom",
@@ -234,4 +235,37 @@ end
     | findall/xf-iter  | 10 ± 2 ns |"""
 
     @test truth ≈ s
+end
+
+@testset "Dirty repo" begin
+    # Create a package with a dirty repo:
+    tmp_dir = mktempdir(; cleanup=false)
+    cd(tmp_dir)
+    Pkg.generate("TestPackage")
+    path = joinpath(tmp_dir, "TestPackage")
+    run(`git -C $path init`)
+    # write benchmarks.jl in the package:
+    script = joinpath(path, "bench.jl")
+    open(joinpath(script), "w") do io
+        write(
+            io,
+            """
+            using BenchmarkTools
+            using TestPackage
+            const SUITE = BenchmarkGroup()
+            SUITE["cos"] = @benchmarkable cos(x) setup=(x=rand())
+            """,
+        )
+    end
+    # place to store the results:
+    results_dir = mktempdir(; cleanup=false)
+    # test the dirty repo:
+    benchpkg(
+        "TestPackage";
+        rev="dirty",
+        script=script,
+        path=path,
+        output_dir=results_dir,
+    )
+    @test isfile(joinpath(results_dir, "results_TestPackage@dirty.json"))
 end


### PR DESCRIPTION
Passing `dirty` as one of the `revs` will benchmark the local state of the package by using [`Package.develop`](https://pkgdocs.julialang.org/v1/managing-packages/#developing) instead of `Package.add` (see #30).

Things I was not sure about:

- How should we test this on the `CI`?
- Do you want the docstrings of `benchpkg` to be updated? I am not sure how useful this feature is for most people, so I did not want to clutter the `rev` description with an explanation of what `dirty` means as a `rev`

