### PR TITLE
Update README.md to make image render in generated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ benchpkgplot Transducers \
 which will generate a pdf file for each set of 5 plots,
 showing the change with each revision:
 
-<img width="877" alt="Screenshot 2023-04-03 at 10 36 16 AM" src="https://user-images.githubusercontent.com/7593028/229543368-14b1da88-8315-437b-b38f-fff143f26e3a.png">
+![runtime_at_versions](https://user-images.githubusercontent.com/7593028/229543368-14b1da88-8315-437b-b38f-fff143f26e3a.png)
 
 You can also provide a custom benchmark.
 For example, let's say you have a file `script.jl`, defining


### PR DESCRIPTION
The html image tag does not render [here](https://astroautomata.com/AirspeedVelocity.jl/stable/#Examples). The markdown image syntax below does render, so I copped that syntax here.