### PR TITLE
Delete unnecessary import of AirspeedVelocity from benchmarks.jl

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,6 +1,5 @@
 # This "benchmark" is only a demo; it is not a real benchmark.
 using BenchmarkTools
-using AirspeedVelocity
 
 const SUITE = BenchmarkGroup()
 


### PR DESCRIPTION
IIUC, one can define an AirspeedVelocity-compatable benchmark suite without loading or depending on AirspeedVelocity.