### PR TITLE
Less invasive installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ https://github.com/MilesCranmer/AirspeedVelocity.jl/assets/7593028/f27b04ef-8491
 You can install the CLI with:
 
 ```bash
-julia -e 'using Pkg; Pkg.add("AirspeedVelocity"); Pkg.build("AirspeedVelocity")'
+julia -e 'using Pkg; Pkg.activate(temp=true); Pkg.add("AirspeedVelocity")'
 ```
 
 This will install two executables at `~/.julia/bin` - make sure to have it on your `PATH`.


### PR DESCRIPTION
Copies installation instructions from [ChairmarksForAirspeedVelocity.jl](https://github.com/LilithHafner/ChairmarksForAirspeedVelocity.jl/tree/4a5b7a16516770f6f3f3318c2198ec21acc2cffa), tested [here](https://github.com/LilithHafner/ChairmarksForAirspeedVelocity.jl/blob/4a5b7a16516770f6f3f3318c2198ec21acc2cffa/test/runtests.jl#L59).

Fixes #45 by clarifying that yes, there is no need to keep (or ever have) AirspeedVelocity.jl in your default environment to use the CLI.