### PR TITLE
Try to guess the default branch and throw better errors when it can't be found

### DIFF
--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -582,19 +582,51 @@ end
 """
 Fill in the default branch if needed.
 """
-function parse_rev(rev::String, path::String)
-    if rev != "{DEFAULT}"
-        return rev
-    end
+parse_rev(rev::String, path::String) = rev == "{DEFAULT}" ? default_branch() : rev
+
+const DEFAULT_BRANCH_NAMES = [
+    "main", "master", "trunk", "dev", "devel", "develop", "default"
+]
+function default_branch()
+    # See if we can determine the default branch locally:
+    default_branches = [
+        line for line in eachline(`git branch --format="%(refname:short)"`) if
+        line ∈ DEFAULT_BRANCH_NAMES
+    ]
+    length(default_branches) == 1 && return only(default_branches)
+
+    # If not, try to get it from the remote:
     cmd = `git remote show origin`
     # Execute the command and capture the output
-    output = read(cmd, String)
+    output = try
+        read(cmd, String)
+    catch
+        throw_default_branch_error(default_branches, false)
+    end
     # Parse the output to find the default branch
     default_branch_line = match(r"HEAD branch: (\w+)", output)
-    default_branch_line === nothing && error(
-        "Default branch not found in the remote repository information:\n\n```\n$output\n```",
-    )
+    default_branch_line === nothing && throw_default_branch_error(default_branches, true)
     return String(default_branch_line.captures[1])::String
+end
+
+function throw_default_branch_error(branches, cmd_succeeded)
+    branch_detail = if isempty(branches)
+        "none of $(join(DEFAULT_BRANCH_NAMES, ", ")) found"
+    else
+        "couldn't decide which of $(join(branches, ", ")) is the default"
+    end
+    remote_detail = if cmd_succeeded
+        "the result of `git remote show origin` didn't specify the a HEAD branch"
+    else
+        "`git remote show origin` failed"
+    end
+    return error(
+        """
+      Unable to determine the default branch locally ($branch_detail).
+      Also unnable to determine the default branch by querying the remote ($remote_detail).
+      You can typically bypass this error by specifying the version manually (i.e. pass `-rev=...` to the CLI)
+      """,
+    )
 end
 
 end # module AirspeedVelocity.Utils

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -352,6 +352,7 @@ end
 
 @testitem "default_branch()" begin
     @test AirspeedVelocity.Utils.default_branch() == "master"
+    run(pipeline(ignorestatus(`git branch master`), stderr=devnull)) # On CI, this branch might not actually exist.
     run(`git branch trunk`)
     @test AirspeedVelocity.Utils.default_branch() == "master" # This requires internet access
     run(`git branch -d trunk`)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -349,3 +349,14 @@ end
     other_rev = parse_rev("my-rev", tmpdir)
     @test other_rev == "my-rev"
 end
+
+@testitem "default_branch()" begin
+    @test AirspeedVelocity.Utils.default_branch() == "master"
+    run(`git branch trunk`)
+    @test AirspeedVelocity.Utils.default_branch() == "master" # This requires internet access
+    run(`git branch -d trunk`)
+    @test AirspeedVelocity.Utils.default_branch() == "master"
+    @test AirspeedVelocity.Utils.parse_rev("{DEFAULT}", "unused") == "master"
+    @test AirspeedVelocity.Utils.parse_rev("lh/guess-default-branch", "unused") ==
+        "lh/guess-default-branch"
+end


### PR DESCRIPTION
Fixes #64

Also makes `parse_rev("{DEFAULT}", "...")` 3 orders of magnitude faster, from `674.089 ms (86 allocs: 133.320 KiB)` to `482.086 μs (101 allocs: 67.633 KiB)`. Hopefully someday we'll be fast enough that that half second will matter.