### PR TITLE
Divide column 3 by column 2 instead of the other way around when computing ratios

### DIFF
--- a/src/TableUtils.jl
+++ b/src/TableUtils.jl
@@ -121,14 +121,14 @@ function create_table(
         col = String[]
         for row in all_keys
             if all(r -> haskey(r, row), values(combined_results))
-                ratio = (/)([val[row][key] for val in values(combined_results)]...)
+                ratio = (/)(reverse!([val[row][key] for val in values(combined_results)])...)
                 push!(col, @sprintf("%.3g", ratio))
             else
                 push!(col, "")
             end
         end
         push!(data_columns, col)
-        push!(headers, "$(headers[2]) / $(headers[3])")
+        push!(headers, "$(headers[3]) / $(headers[2])")
         num_cols += 1
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -212,19 +212,19 @@ end
     )
 
     truth = """
-    |        | v1           | v2         | v1 / v2 |
+    |        | v1           | v2         | v2 / v1 |
     |:-------|:------------:|:----------:|:-------:|
-    | bench1 | 1.2 ± 0.2 s  | 12 ± 2 s   | 0.1     |
-    | bench2 | 0.2 ± 0.2 ms | 20 ± 20 μs | 10      |
+    | bench1 | 1.2 ± 0.2 s  | 12 ± 2 s   | 10      |
+    | bench2 | 0.2 ± 0.2 ms | 20 ± 20 μs | 0.1     |
     | bench3 |              | 20 ± 20 μs |         |
     """
     @test truth ≈ create_table(combined_results)
 
     truth = """
-    |        | v1                 | v2                | v1 / v2 |
+    |        | v1                 | v2                | v2 / v1 |
     |:-------|:------------------:|:-----------------:|:-------:|
-    | bench1 | 1  allocs: 10 B    | 2  allocs: 1 kB   | 0.00977 |
-    | bench2 | 1 M allocs: 0.1 kB | 3  allocs: 10 kB  | 0.01    |
+    | bench1 | 1  allocs: 10 B    | 2  allocs: 1 kB   | 102.4   |
+    | bench2 | 1 M allocs: 0.1 kB | 3  allocs: 10 kB  | 100     |
     | bench3 |                    | 4  allocs: 0.1 MB |         |
     """
     @test truth ≈ create_table(


### PR DESCRIPTION
From https://github.com/LilithHafner/DynamicDiscreteSamplers.jl/pull/113#issuecomment-2678362276.

In my experience, it is more natural for a high number to mean worse and a low number to mean better when working with benchmarks. To produce this, I'd like to divide new/old to compute ratios. I'd also like to display new first, followed by old, in chronological order. i.e.

### Benchmark Results


|                               | main   | pr   | pr / main |
|:------------------------------|:-------------------:|:-------------------:|:-----------------------------------:|
| construction             | 1.93 ± 0.19 μs      | 0.95 ± 0.19 μs      |0.492|
| sampling             | 1.03 ± 0.19 μs      | 3.95 ± 0.19 μs      |3.84|

This PR makes that change by displaying ratios as column 3 divided by column 2.
