### PR TITLE
Handle sources in Project.toml + unregistered packages

### DIFF
--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -145,17 +145,18 @@ function _benchmark(
     end
     Pkg.activate(tmp_env; io=devnull)
     @info "    Adding packages."
-    # Filter out empty strings from extra_pkgs:
-    extra_pkgs = filter(x -> x != "", extra_pkgs)
-    pkgs = ["BenchmarkTools", "JSON3", "Pkg", "TOML", extra_pkgs...]
-    # Add extra packages. A "dirty" rev means we want to benchmark the local
+    # "dirty" rev means we want to benchmark the local
     # version of the package at `path`.
-    Pkg.add([parse_package_spec(pkg) for pkg in pkgs]; io=devnull)
     if spec.rev == "dirty"
         Pkg.develop(; path=spec.path, io=devnull)
     else
         Pkg.add(spec; io=devnull)
     end
+    # Filter out empty strings from extra_pkgs:
+    extra_pkgs = filter(x -> x != "", extra_pkgs)
+    pkgs = ["BenchmarkTools", "JSON3", "Pkg", "TOML", extra_pkgs...]
+    # Add extra packages
+    Pkg.add([parse_package_spec(pkg) for pkg in pkgs]; io=devnull)
     Pkg.precompile()
     Pkg.activate(old_project; io=devnull)
     results_filename = joinpath(output_dir, "results_" * spec_str * ".json")


### PR DESCRIPTION
- **Handle `[sources]` entry for package being benchmarked** fixes #92 
- **Change order of operations to support non-registered packages** fixes #84
