### PR TITLE
Overhaul GitHub action

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -1,78 +1,23 @@
 name: Benchmark a pull request
 
 on:
-  pull_request_target:
-    branches:
-      - master
+  pull_request_target:          # keeps the write token for forked PRs
+    branches: [ master ]        # change if your default branch differs
 
 permissions:
   pull-requests: write
 
 jobs:
-    generate_plots:
-        runs-on: ubuntu-latest
-
-        steps:
-            - uses: actions/checkout@v4
-            - uses: julia-actions/setup-julia@v2
-              with:
-                version: "1.8"
-            - uses: julia-actions/cache@v2
-            - name: Extract Package Name from Project.toml
-              id: extract-package-name
-              run: |
-                PACKAGE_NAME=$(grep "^name" Project.toml | sed 's/^name = "\(.*\)"$/\1/')
-                echo "::set-output name=package_name::$PACKAGE_NAME"
-            - name: Build AirspeedVelocity
-              env:
-                JULIA_NUM_THREADS: 2
-              run: |
-                # Lightweight build step, as sometimes the runner runs out of memory:
-                julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.add(;url="https://github.com/MilesCranmer/AirspeedVelocity.jl.git")'
-                julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.build("AirspeedVelocity")'
-            - name: Add ~/.julia/bin to PATH
-              run: |
-                echo "$HOME/.julia/bin" >> $GITHUB_PATH
-            - name: Run benchmarks
-              run: |
-                echo $PATH
-                ls -l ~/.julia/bin
-                mkdir results
-                benchpkg ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.repository.default_branch}}" --output-dir=results/ --tune
-            - name: Create plots from benchmarks
-              run: |
-                mkdir -p plots
-                benchpkgplot ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --npart=10 --format=png --input-dir=results/ --output-dir=plots/
-            - name: Upload plot as artifact
-              uses: actions/upload-artifact@v4
-              with:
-                name: plots
-                path: plots
-            - name: Create markdown table from benchmarks
-              run: |
-                benchpkgtable ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --input-dir=results/ --ratio > table.md
-                echo '### Benchmark Results' > body.md
-                echo '' >> body.md
-                echo '' >> body.md
-                cat table.md >> body.md
-                echo '' >> body.md
-                echo '' >> body.md
-                echo '### Benchmark Plots' >> body.md
-                echo 'A plot of the benchmark results have been uploaded as an artifact to the workflow run for this PR.' >> body.md
-                echo 'Go to "Actions"->"Benchmark a pull request"->[the most recent run]->"Artifacts" (at the bottom).' >> body.md
-
-            - name: Find Comment
-              uses: peter-evans/find-comment@v3
-              id: fcbenchmark
-              with:
-                issue-number: ${{ github.event.pull_request.number }}
-                comment-author: 'github-actions[bot]'
-                body-includes: Benchmark Results
-
-            - name: Comment on PR
-              uses: peter-evans/create-or-update-comment@v4
-              with:
-                comment-id: ${{ steps.fcbenchmark.outputs.comment-id }}
-                issue-number: ${{ github.event.pull_request.number }}
-                body-path: body.md
-                edit-mode: replace
+  bench:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        julia-version: [1, 1.10]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Run AirspeedVelocity composite action (local path)
+        uses: ./                  # uses action.yml at the repo root
+        with:
+          julia-version: ${{ matrix.julia-version }}

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,8 @@ runs:
     - id: pkg
       shell: bash
       run: |
-        echo "package_name=$(grep '^name' Project.toml | sed 's/^name = \"\(.*\)\"/\\1/')" >> "$GITHUB_OUTPUT"
+        pkg=$(awk -F' *= *' '/^name *=/ {gsub(/"/,"",$2); print $2; exit}' Project.toml)
+        echo "package_name=$pkg" >> "$GITHUB_OUTPUT"
 
     # Assemble optional flags
     - id: flags
@@ -59,7 +60,7 @@ runs:
         if [[ -n "${{ inputs.rev }}" ]]; then
           f+=("--rev=${{ inputs.rev }}")
         else
-          f+=("--rev=${{ github.event.repository.default_branch }},${{ github.event.pull_request.head_sha }}")
+          f+=("--rev=${{ github.event.repository.default_branch }},${{ github.event.pull_request.head.sha }}")
         fi
 
         # --bench-on : default to the repository default branch unless caller overrides

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,8 @@ runs:
         ref: ${{ github.event.pull_request.head.sha }}
 
     - uses: julia-actions/setup-julia@v2
-      with: { version: ${{ inputs.julia-version }} }
+      with:
+        version: ${{ inputs.julia-version }}
 
     - uses: julia-actions/cache@v2
 

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,8 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - uses: julia-actions/setup-julia@v2
       with: { version: ${{ inputs.julia-version }} }

--- a/action.yml
+++ b/action.yml
@@ -23,33 +23,34 @@ runs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
-    - uses: julia-actions/setup-julia@v2
+    - name: Setup Julia
+      uses: julia-actions/setup-julia@v2
       with:
         version: ${{ inputs.julia-version }}
 
-    - uses: julia-actions/cache@v2
+    - name: Cache Julia packages
+      uses: julia-actions/cache@v2
 
-    # Install + build AirspeedVelocity
-    - name: Build AirspeedVelocity
+    - name: Install and build AirspeedVelocity
       shell: bash
       run: |
         export JULIA_NUM_THREADS=2
         # Lightweight build step, as sometimes the runner runs out of memory:
         julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; using Pkg; pkg"add AirspeedVelocity@${{ inputs.asv-version }}"'
 
-    - run: echo "$HOME/.julia/bin" >> "$GITHUB_PATH"
+    - name: Add ~/.julia/bin to PATH
+      run: echo "$HOME/.julia/bin" >> "$GITHUB_PATH"
       shell: bash
-      name: Add ~/.julia/bin to PATH
 
-    # Package name from Project.toml
-    - id: pkg
+    - name: Get package name
+      id: pkg
       shell: bash
       run: |
         pkg=$(awk -F' *= *' '/^name *=/ {gsub(/"/,"",$2); print $2; exit}' Project.toml)
         echo "package_name=$pkg" >> "$GITHUB_OUTPUT"
 
-    # Assemble optional flags
-    - id: flags
+    - name: Assemble benchpkg flags
+      id: flags
       shell: bash
       run: |
         # Build separate argument lists:
@@ -98,9 +99,9 @@ runs:
           ${{ steps.flags.outputs.bench_args }}
 
     # Optional plots
-    - if: ${{ inputs.enable-plots == 'true' }}
+    - name: Generate plots
+      if: ${{ inputs.enable-plots == 'true' }}
       shell: bash
-      name: Generate plots
       run: |
         mkdir -p plots
         benchpkgplot "${{ steps.pkg.outputs.package_name }}" \
@@ -110,15 +111,17 @@ runs:
           --npart=10 \
           ${{ steps.flags.outputs.table_args }}
 
-    - if: ${{ inputs.enable-plots == 'true' }}
+    - name: Upload plots
+      if: ${{ inputs.enable-plots == 'true' }}
       uses: actions/upload-artifact@v4
-      with: { name: benchmark-plots, path: plots }
+      with:
+        name: benchmark-plots
+        path: plots
 
-    # Build markdown
-    - name: Create markdown body
+    - name: Create comment body
       shell: bash
       run: |
-        echo "### Benchmark Results (Julia ${{ inputs.julia-version }})" > body.md
+        echo "### Benchmark Results (Julia v${{ inputs.julia-version }})" > body.md
         echo "" >> body.md
 
         # One independent <details> block per requested mode
@@ -144,15 +147,16 @@ runs:
           } >> body.md
         fi
 
-    # Comment update
-    - uses: peter-evans/find-comment@v3
+    - name: Find comment
+      uses: peter-evans/find-comment@v3
       id: find
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: 'github-actions[bot]'
         body-includes: "Benchmark Results (Julia ${{ inputs.julia-version }})"
 
-    - uses: peter-evans/create-or-update-comment@v4
+    - name: Create or update comment
+      uses: peter-evans/create-or-update-comment@v4
       with:
         comment-id: ${{ steps.find.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,6 @@ runs:
         export JULIA_NUM_THREADS=2
         # Lightweight build step, as sometimes the runner runs out of memory:
         julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; using Pkg; pkg"add AirspeedVelocity@${{ inputs.asv-version }}"'
-        julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.build("AirspeedVelocity")'
 
     - run: echo "$HOME/.julia/bin" >> "$GITHUB_PATH"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -52,30 +52,40 @@ runs:
     - id: flags
       shell: bash
       run: |
-        # Build argument list for benchpkg / benchpkgplot / benchpkgtable
-        f=()
+        # Build separate argument lists:
+        #   bench_args -> for `benchpkg`
+        #   table_args -> for `benchpkgtable` and `benchpkgplot`
+        bench_args=()
+        table_args=()
 
         # --rev : default to <default_branch>,<PR_SHA> when caller did not override
         if [[ -n "${{ inputs.rev }}" ]]; then
-          f+=("--rev=${{ inputs.rev }}")
+          bench_args+=("--rev=${{ inputs.rev }}")
+          table_args+=("--rev=${{ inputs.rev }}")
         else
-          f+=("--rev=${{ github.event.repository.default_branch }},${{ github.event.pull_request.head.sha }}")
+          revs="${{ github.event.repository.default_branch }},${{ github.event.pull_request.head.sha }}"
+          bench_args+=("--rev=${revs}")
+          table_args+=("--rev=${revs}")
         fi
 
         # --bench-on : default to the repository default branch unless caller overrides
         if [[ -n "${{ inputs.bench-on }}" ]]; then
-          f+=("--bench-on=${{ inputs.bench-on }}")
+          bench_args+=("--bench-on=${{ inputs.bench-on }}")
         else
-          f+=("--bench-on=${{ github.event.repository.default_branch }}")
+          branch="${{ github.event.repository.default_branch }}"
+          bench_args+=("--bench-on=${branch}")
         fi
 
-        [[ -n "${{ inputs.script }}"   ]] && f+=("--script=${{ inputs.script }}")
-        [[ -n "${{ inputs.filter }}"   ]] && f+=("--filter=${{ inputs.filter }}")
-        [[ -n "${{ inputs.exeflags }}" ]] && f+=("--exeflags='${{ inputs.exeflags }}'")
-        [[ -n "${{ inputs.extra-pkgs }}" ]] && f+=("--add=${{ inputs.extra-pkgs }}")
-        [[ "${{ inputs.tune }}" == 'true' ]] && f+=("--tune")
+        # Options that apply **only** to benchpkg
+        [[ -n "${{ inputs.script }}"       ]] && bench_args+=("--script=${{ inputs.script }}")
+        [[ -n "${{ inputs.filter }}"       ]] && bench_args+=("--filter=${{ inputs.filter }}")
+        [[ -n "${{ inputs.exeflags }}"     ]] && bench_args+=("--exeflags='${{ inputs.exeflags }}'")
+        [[ -n "${{ inputs.extra-pkgs }}"   ]] && bench_args+=("--add=${{ inputs.extra-pkgs }}")
+        [[ "${{ inputs.tune }}" == 'true'  ]] && bench_args+=("--tune")
 
-        echo "args=${f[*]}" >> "$GITHUB_OUTPUT"
+        # Export as composite-action outputs
+        echo "bench_args=${bench_args[*]}" >> "$GITHUB_OUTPUT"
+        echo "table_args=${table_args[*]}" >> "$GITHUB_OUTPUT"
 
     # Run benchmarks
     - name: Run benchmarks
@@ -85,7 +95,7 @@ runs:
         benchpkg "${{ steps.pkg.outputs.package_name }}" \
           --url="${{ github.event.repository.clone_url }}" \
           --output-dir=results/ \
-          ${{ steps.flags.outputs.args }}
+          ${{ steps.flags.outputs.bench_args }}
 
     # Optional plots
     - if: ${{ inputs.enable-plots == 'true' }}
@@ -98,7 +108,7 @@ runs:
           --output-dir=plots/ \
           --format=png \
           --npart=10 \
-          ${{ steps.flags.outputs.args }}
+          ${{ steps.flags.outputs.table_args }}
 
     - if: ${{ inputs.enable-plots == 'true' }}
       uses: actions/upload-artifact@v4
@@ -121,7 +131,7 @@ runs:
               --input-dir=results/ \
               --mode=$m \
               --ratio \
-              ${{ steps.flags.outputs.args }}
+              ${{ steps.flags.outputs.table_args }}
             echo ""
             echo "</details>"
             echo ""

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,3 @@
-# action.yml ─ v1.1
 name: 'Benchmark PR with AirspeedVelocity'
 description: 'Compare PR performance (time/memory) against the default branch and comment results'
 author: 'Miles Cranmer'

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,148 @@
+# action.yml ─ v1.1
+name: 'Benchmark PR with AirspeedVelocity'
+description: 'Compare PR performance (time/memory) against the default branch and comment results'
+author: 'Miles Cranmer'
+branding: { icon: activity, color: purple }
+
+inputs:
+  asv-version:   { default: '0.6',          description: 'AirspeedVelocity version' }
+  julia-version: { default: '1',            description: 'Julia version' }
+  mode:          { default: 'time,memory',  description: 'Comma-separated list of modes for benchpkgtable (e.g. time,memory)' }
+  enable-plots:  { default: 'false',        description: 'Generate & upload plots' }
+  tune:          { default: 'false',        description: 'Pass --tune to benchpkg' }
+  script:        { default: '',             description: 'Custom benchmark script path' }
+  rev:           { default: '',             description: '--rev list for benchpkg' }
+  bench-on:      { default: '',             description: '--bench-on commit to freeze script' }
+  filter:        { default: '',             description: '--filter list for benchpkg' }
+  exeflags:      { default: '',             description: '--exeflags for Julia' }
+  extra-pkgs:    { default: '',             description: '--add extra packages (comma-sep)' }
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+
+    - uses: julia-actions/setup-julia@v2
+      with: { version: ${{ inputs.julia-version }} }
+
+    - uses: julia-actions/cache@v2
+
+    # Install + build AirspeedVelocity
+    - name: Build AirspeedVelocity
+      shell: bash
+      run: |
+        export JULIA_NUM_THREADS=2
+        # Lightweight build step, as sometimes the runner runs out of memory:
+        julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; using Pkg; pkg"add AirspeedVelocity@${{ inputs.asv-version }}"'
+        julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.build("AirspeedVelocity")'
+
+    - run: echo "$HOME/.julia/bin" >> "$GITHUB_PATH"
+      shell: bash
+      name: Add ~/.julia/bin to PATH
+
+    # Package name from Project.toml
+    - id: pkg
+      shell: bash
+      run: |
+        echo "package_name=$(grep '^name' Project.toml | sed 's/^name = \"\(.*\)\"/\\1/')" >> "$GITHUB_OUTPUT"
+
+    # Assemble optional flags
+    - id: flags
+      shell: bash
+      run: |
+        # Build argument list for benchpkg / benchpkgplot / benchpkgtable
+        f=()
+
+        # --rev : default to <default_branch>,<PR_SHA> when caller did not override
+        if [[ -n "${{ inputs.rev }}" ]]; then
+          f+=("--rev=${{ inputs.rev }}")
+        else
+          f+=("--rev=${{ github.event.repository.default_branch }},${{ github.event.pull_request.head_sha }}")
+        fi
+
+        # --bench-on : default to the repository default branch unless caller overrides
+        if [[ -n "${{ inputs.bench-on }}" ]]; then
+          f+=("--bench-on=${{ inputs.bench-on }}")
+        else
+          f+=("--bench-on=${{ github.event.repository.default_branch }}")
+        fi
+
+        [[ -n "${{ inputs.script }}"   ]] && f+=("--script=${{ inputs.script }}")
+        [[ -n "${{ inputs.filter }}"   ]] && f+=("--filter=${{ inputs.filter }}")
+        [[ -n "${{ inputs.exeflags }}" ]] && f+=("--exeflags='${{ inputs.exeflags }}'")
+        [[ -n "${{ inputs.extra-pkgs }}" ]] && f+=("--add=${{ inputs.extra-pkgs }}")
+        [[ "${{ inputs.tune }}" == 'true' ]] && f+=("--tune")
+
+        echo "args=${f[*]}" >> "$GITHUB_OUTPUT"
+
+    # Run benchmarks
+    - name: Run benchmarks
+      shell: bash
+      run: |
+        mkdir results
+        benchpkg "${{ steps.pkg.outputs.package_name }}" \
+          --url="${{ github.event.repository.clone_url }}" \
+          --output-dir=results/ \
+          ${{ steps.flags.outputs.args }}
+
+    # Optional plots
+    - if: ${{ inputs.enable-plots == 'true' }}
+      shell: bash
+      name: Generate plots
+      run: |
+        mkdir -p plots
+        benchpkgplot "${{ steps.pkg.outputs.package_name }}" \
+          --input-dir=results/ \
+          --output-dir=plots/ \
+          --format=png \
+          --npart=10 \
+          ${{ steps.flags.outputs.args }}
+
+    - if: ${{ inputs.enable-plots == 'true' }}
+      uses: actions/upload-artifact@v4
+      with: { name: benchmark-plots, path: plots }
+
+    # Build markdown
+    - name: Create markdown body
+      shell: bash
+      run: |
+        echo "### Benchmark Results (Julia ${{ inputs.julia-version }})" > body.md
+        echo "" >> body.md
+
+        # One independent <details> block per requested mode
+        IFS=',' read -ra MODES <<< "${{ inputs.mode }}"
+        for m in "${MODES[@]}"; do
+          {
+            echo "<details><summary>${m^} benchmarks</summary>"
+            echo ""
+            benchpkgtable "${{ steps.pkg.outputs.package_name }}" \
+              --input-dir=results/ \
+              --mode=$m \
+              --ratio \
+              ${{ steps.flags.outputs.args }}
+            echo ""
+            echo "</details>"
+            echo ""
+          } >> body.md
+        done
+
+        if [[ "${{ inputs.enable-plots }}" == 'true' ]]; then
+          {
+            echo 'A plot of the benchmark results has been uploaded as an artifact at ${{ steps.artifact-upload-step.outputs.artifact-url }}.'
+          } >> body.md
+        fi
+
+    # Comment update
+    - uses: peter-evans/find-comment@v3
+      id: find
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: "Benchmark Results (Julia ${{ inputs.julia-version }})"
+
+    - uses: peter-evans/create-or-update-comment@v4
+      with:
+        comment-id: ${{ steps.find.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body-path: body.md
+        edit-mode: replace

--- a/action.yml
+++ b/action.yml
@@ -121,7 +121,7 @@ runs:
     - name: Create comment body
       shell: bash
       run: |
-        echo "### Benchmark Results (Julia v${{ inputs.julia-version }})" > body.md
+        echo "## Benchmark Results (Julia v${{ inputs.julia-version }})" > body.md
         echo "" >> body.md
 
         # One independent <details> block per requested mode

--- a/src/TableUtils.jl
+++ b/src/TableUtils.jl
@@ -139,7 +139,8 @@ function create_table(
             @assert length(vals) == 2
             ratio = vals[1] / vals[2]
 
-            compute_ratio_err = all(haskey(s, "25") && haskey(s, "75") for s in stats) && key == "median"
+            compute_ratio_err =
+                all(haskey(s, "25") && haskey(s, "75") for s in stats) && key == "median"
             ratio_err = if compute_ratio_err
                 errs = [max(0.0, s["75"] - s["25"]) for s in stats]
                 abs(ratio) * sqrt((errs[1] / vals[1])^2 + (errs[2] / vals[2])^2)


### PR DESCRIPTION
This creates a re-usable marketplace action so you can get AirspeedVelocity benchmarks with:

```yaml
name: Benchmark on multiple Julia versions
on: pull_request
permissions:
  pull-requests: write

jobs:
  bench:
    runs-on: ubuntu-latest
    strategy:
      matrix:
        julia: ['1.10', '1.11']
    steps:
      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1  #[once its released]
        with:
          julia-version: ${{ matrix.julia }}
```

In other words, this makes it easy to now benchmark on multiple julia versions. Each version will show up as a separate comment in the PR thread.

It also makes the comment now include memory comparisons before/after the PR, and also puts them in collapsible `<details>` blocks.

A lot of the CLI options, like `--tune`, or `--script`, are available as action parameters.

@LilithHafner curious to hear your thoughts!