### PR TITLE
Fix display of special Julia versions (e.g. LTS and pre) in GHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -142,7 +142,7 @@ runs:
       env:
         GITHUB_TOKEN: ""
       run: |
-        echo "## Benchmark Results (Julia v${{ inputs.julia-version }})" > body.md
+        echo "## Benchmark Results (Julia ${{ inputs.julia-version }})" > body.md
         echo "" >> body.md
 
         # One independent <details> block per requested mode
@@ -182,7 +182,7 @@ runs:
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: 'github-actions[bot]'
-        body-includes: "Benchmark Results (Julia v${{ inputs.julia-version }})"
+        body-includes: "Benchmark Results (Julia ${{ inputs.julia-version }})"
 
     - name: Create or update comment
       if: ${{ inputs.job-summary != 'true' }}


### PR DESCRIPTION
Currently, the title of the comment created by the action reads "Julia vlts" when running tests with the `'lts'` Julia version: https://github.com/JuliaNLSolvers/Optim.jl/pull/1198#issuecomment-3479462777

I think it would be easiest to just generally drop the `'v'` from the title.