### PR TITLE
Use Julia version in plot artifact name to avoid name collisions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -134,7 +134,7 @@ runs:
       if: ${{ inputs.enable-plots == 'true' }}
       uses: actions/upload-artifact@v4
       with:
-        name: benchmark-plots
+        name: benchmark-plots-${{ inputs.julia-version }}
         path: plots
 
     - name: Create comment body


### PR DESCRIPTION
The action failed in https://github.com/JuliaNLSolvers/Optim.jl/actions/runs/19761800616/job/56625274453?pr=1212 (BTW on 1.12.2 which seems to contain the fix for #113) because an artifact of the name "benchmark-plots" already existed. I suggest adding the Julia version to the artifact name.