### PR TITLE
feat: add emoji indicators to ratio column

### DIFF
--- a/src/TableUtils.jl
+++ b/src/TableUtils.jl
@@ -164,9 +164,25 @@ function create_table(
             else
                 NaN
             end
+            status = :neutral
+            if isfinite(ratio) && isfinite(ratio_err)
+                if ratio + ratio_err < 0.8
+                    status = :slowdown
+                elseif ratio - ratio_err > 1.2
+                    status = :speedup
+                end
+            elseif isfinite(ratio)
+                if ratio < 0.5
+                    status = :speedup
+                elseif ratio > 1.5
+                    status = :slowdown
+                end
+            end
+
             string_ratio = join((
                 isfinite(ratio) ? @sprintf("%.3g", ratio) : "",
                 isfinite(ratio_err) ? @sprintf(" ± %.2g", ratio_err) : "",
+                (; speedup=" 🚀", neutral="", slowdown=" 🐢")[status],
             ))
 
             push!(col, string_ratio)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -214,20 +214,20 @@ end
     )
 
     truth = """
-    |        | v1           | v2         | v1 / v2     |
-    |:-------|:------------:|:----------:|:-----------:|
-    | bench1 | 1.2 ± 0.2 s  | 12 ± 2 s   | 0.1 ± 0.024 |
-    | bench2 | 0.2 ± 0.2 ms | 20 ± 20 μs | 10 ± 14     |
-    | bench3 |              | 20 ± 20 μs |             |
+    |        | v1           | v2         | v1 / v2       |
+    |:-------|:------------:|:----------:|:-------------:|
+    | bench1 | 1.2 ± 0.2 s  | 12 ± 2 s   | 0.1 ± 0.024 🐢 |
+    | bench2 | 0.2 ± 0.2 ms | 20 ± 20 μs | 10 ± 14       |
+    | bench3 |              | 20 ± 20 μs |               |
     """
     @test truth ≈ create_table(combined_results)
 
     truth = """
-    |        | v1                 | v2                | v1 / v2 |
-    |:-------|:------------------:|:-----------------:|:-------:|
-    | bench1 | 1  allocs: 10 B    | 2  allocs: 1 kB   | 0.00977 |
-    | bench2 | 1 M allocs: 0.1 kB | 3  allocs: 10 kB  | 0.01    |
-    | bench3 |                    | 4  allocs: 0.1 MB |         |
+    |        | v1                 | v2                | v1 / v2   |
+    |:-------|:------------------:|:-----------------:|:---------:|
+    | bench1 | 1  allocs: 10 B    | 2  allocs: 1 kB   | 0.00977 🚀 |
+    | bench2 | 1 M allocs: 0.1 kB | 3  allocs: 10 kB  | 0.01 🚀    |
+    | bench3 |                    | 4  allocs: 0.1 MB |           |
     """
     @test truth ≈ create_table(
         combined_results; formatter=AirspeedVelocity.TableUtils.format_memory, key="memory"


### PR DESCRIPTION
Add 🚀 (speedup) and 🐢 (slowdown) emoji indicators to the ratio column in benchmark tables.

When uncertainty is available (ratio_err is finite):
- slowdown (🐢): ratio + ratio_err < 0.8
- speedup (🚀): ratio - ratio_err > 1.2

When uncertainty is not available (memory mode):
- speedup (🚀): ratio < 0.5
- slowdown (🐢): ratio > 1.5

Neutral cases show no emoji.

Based on the stale PR #91 by MilesCranmer.