### PR TITLE
feat: add post-comment input for optional fork-safe two-stage workflow

### DIFF
--- a/.github/workflows/benchmark_pr_forksafe.yml
+++ b/.github/workflows/benchmark_pr_forksafe.yml
@@ -1,8 +1,12 @@
-name: Benchmark a pull request
+name: Benchmark PR (fork-safe)
 
 on:
-  pull_request:          # keeps the write token for forked PRs
+  pull_request:
     branches: [ master ]        # change if your default branch differs
+
+# No special permissions needed — the action uploads an artifact
+# instead of commenting directly. A separate workflow_run workflow
+# (post_benchmark_comment.yml) picks up the artifact and posts the comment.
 
 jobs:
   bench:
@@ -18,4 +22,4 @@ jobs:
         uses: ./                  # uses action.yml at the repo root
         with:
           julia-version: ${{ matrix.julia-version }}
-          job-summary: 'true'
+          post-comment: 'false'

--- a/.github/workflows/post_benchmark_comment.yml
+++ b/.github/workflows/post_benchmark_comment.yml
@@ -1,0 +1,23 @@
+name: Post Benchmark Comment
+
+on:
+  workflow_run:
+    workflows: ["Benchmark PR (fork-safe)"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_commit.id }}
+      - name: Post benchmark comments
+        uses: ./post-comment
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ https://github.com/MilesCranmer/AirspeedVelocity.jl/assets/7593028/f27b04ef-8491
   - [Using in CI](#using-in-ci)
     - [Option 1: PR Comments](#option-1-pr-comments)
     - [Option 2: Job Summary](#option-2-job-summary)
+    - [Option 3: PR Comments (fork-safe)](#option-3-pr-comments-fork-safe)
     - [Multiple Julia versions](#multiple-julia-versions)
     - [CI Parameters](#ci-parameters)
   - [Further examples](#further-examples)
@@ -61,7 +62,7 @@ See the [further examples](#further-examples) for more details.
 
 ## Using in CI
 
-AirspeedVelocity.jl provides two ways to display benchmark results in GitHub Actions:
+AirspeedVelocity.jl provides three ways to display benchmark results in GitHub Actions:
 
 ### Option 1: PR Comments
 
@@ -109,6 +110,63 @@ jobs:
 
 Both workflows run AirspeedVelocity and display results with separate, collapsible tables for runtime and memory.
 
+### Option 3: PR Comments (fork-safe)
+
+When PRs come from forks, `pull_request` workflows run with read-only permissions
+and cannot post PR comments. Option 1 requires `pull_request_target` to work around this,
+but that runs the PR's code with elevated privileges — a security risk.
+
+This option uses a two-stage approach: the benchmark runs in a read-only `pull_request`
+workflow and uploads results as an artifact, then a separate privileged `workflow_run`
+workflow posts the comment.
+
+Add two workflow files to your package:
+
+**`.github/workflows/benchmark.yml`** — runs benchmarks (no write permissions needed):
+
+```yaml
+name: Benchmark this PR
+on:
+  pull_request:
+    branches: [ master ]  # change to your default branch
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: '1'
+          post-comment: 'false'
+```
+
+**`.github/workflows/post_benchmark_comment.yml`** — posts comments (privileged):
+
+```yaml
+name: Post Benchmark Comment
+on:
+  workflow_run:
+    workflows: ["Benchmark this PR"] # this should match the name of the benchmark workflow
+    types: [completed]               # only run when the benchmark workflow finishes
+
+permissions:
+  pull-requests: write               # needed to post comments
+
+jobs:
+  comment:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl/post-comment@action-v1
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+```
+
+> **Note:** The `workflow_run` trigger requires the commenter workflow file to exist
+> on the default branch. You must merge the commenter workflow to your default branch
+> before the two-stage flow will work.
+
 ### Multiple Julia versions
 
 ```yaml
@@ -122,7 +180,7 @@ steps:
       julia-version: ${{ matrix.julia }}
 ```
 
-Each matrix leg writes its own comment (Option 1) or section in the job summary (Option 2).
+Each matrix leg writes its own comment (Option 1 or Option 3) or section in the job summary (Option 2).
 
 ### CI Parameters
 
@@ -131,6 +189,7 @@ Each matrix leg writes its own comment (Option 1) or section in the job summary 
 | `asv-version`     | `"0.6"`          | AirspeedVelocity version to install         |
 | `julia-version`   | `"1"`            | Julia version to install                    |
 | `job-summary`     | `"false"`        | Output to job summary instead of PR comment |
+| `post-comment`    | `"true"`         | Post comment directly or upload as artifact |
 | `tune`            | `"false"`        | `--tune` to tune benchmarks first           |
 | `mode`            | `"time,memory"`  | Which tables to generate (`time`, `memory`) |
 | `enable-plots`    | `"false"`        | Upload PNG plots as artifact                |

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,7 @@ inputs:
   exeflags:      { default: '',             description: '--exeflags for Julia' }
   extra-pkgs:    { default: '',             description: '--add extra packages (comma-sep)' }
   job-summary:   { default: 'false',        description: 'Output to job summary instead of PR comment' }
+  post-comment:  { default: 'true',         description: 'Post results as PR comment directly (true) or upload as artifact for a separate commenter workflow (false)' }
 
 runs:
   using: composite
@@ -179,8 +180,9 @@ runs:
         GITHUB_TOKEN: ""
       run: cat body.md >> "$GITHUB_STEP_SUMMARY"
 
+    # --- Single-stage: post comment directly (default) ---
     - name: Find comment
-      if: ${{ inputs.job-summary != 'true' }}
+      if: ${{ inputs.job-summary != 'true' && inputs.post-comment == 'true' }}
       uses: peter-evans/find-comment@v4
       id: find
       with:
@@ -189,10 +191,30 @@ runs:
         body-includes: "Benchmark Results (Julia v${{ inputs.julia-version }})"
 
     - name: Create or update comment
-      if: ${{ inputs.job-summary != 'true' }}
+      if: ${{ inputs.job-summary != 'true' && inputs.post-comment == 'true' }}
       uses: peter-evans/create-or-update-comment@v5
       with:
         comment-id: ${{ steps.find.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
         body-path: body.md
         edit-mode: replace
+
+    # --- Two-stage: upload artifact for a separate commenter workflow ---
+    - name: Write PR metadata
+      if: ${{ inputs.job-summary != 'true' && inputs.post-comment != 'true' }}
+      shell: bash
+      env:
+        GITHUB_TOKEN: ""
+      run: |
+        echo "${{ github.event.pull_request.number }}" > pr_number.txt
+        echo "${{ inputs.julia-version }}" > julia_version.txt
+
+    - name: Upload benchmark comment artifact
+      if: ${{ inputs.job-summary != 'true' && inputs.post-comment != 'true' }}
+      uses: actions/upload-artifact@v6
+      with:
+        name: benchmark-comment-${{ inputs.julia-version }}
+        path: |
+          body.md
+          pr_number.txt
+          julia_version.txt

--- a/post-comment/action.yml
+++ b/post-comment/action.yml
@@ -1,0 +1,56 @@
+name: Post Benchmark Comment
+description: Download benchmark comment artifacts from a workflow run and post or update PR comments
+author: Miles Cranmer
+branding:
+  icon: activity
+  color: purple
+
+inputs:
+  run-id:
+    description: Workflow run ID that produced benchmark-comment-* artifacts
+    required: true
+  github-token:
+    description: GitHub token with pull-requests write permission
+    required: true
+  artifact-pattern:
+    description: Artifact name pattern to download
+    default: benchmark-comment-*
+
+runs:
+  using: composite
+  steps:
+    - name: Download benchmark artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: ${{ inputs.artifact-pattern }}
+        run-id: ${{ inputs.run-id }}
+        github-token: ${{ inputs.github-token }}
+        path: artifacts
+
+    - name: Post comments
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        shopt -s nullglob
+
+        for dir in artifacts/*/; do
+          pr=$(cat "$dir/pr_number.txt")
+          jv=$(cat "$dir/julia_version.txt")
+
+          comment_id=$(gh api \
+            "repos/${{ github.repository }}/issues/${pr}/comments" \
+            --paginate \
+            --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"Benchmark Results (Julia v${jv})\"))) | .id" \
+            | head -1)
+
+          if [[ -n "$comment_id" ]]; then
+            gh api --method PATCH \
+              "repos/${{ github.repository }}/issues/comments/${comment_id}" \
+              -F body=@"$dir/body.md"
+          else
+            gh api --method POST \
+              "repos/${{ github.repository }}/issues/${pr}/comments" \
+              -F body=@"$dir/body.md"
+          fi
+        done


### PR DESCRIPTION
Add a new 'post-comment' input (default: 'true') that controls how benchmark results are delivered when job-summary is false:

- post-comment='true' (default): Single-stage, posts comments directly using peter-evans/find-comment and peter-evans/create-or-update-comment. This is the existing behavior and requires pull-requests: write.

- post-comment='false': Two-stage mode, uploads benchmark results as an artifact (body.md, pr_number.txt, julia_version.txt). A separate workflow_run workflow can then download the artifact and post the comment with write permissions, keeping the benchmark runner read-only.

Changes:
- action.yml: Add post-comment input, gate comment steps on it, add artifact upload path for two-stage mode
- benchmark_pr_forksafe.yml: New self-test workflow for two-stage path
- post_benchmark_comment.yml: Commenter workflow triggered by workflow_run
- README.md: Document Option 3 (fork-safe PR comments) and post-comment parameter

---

**The problem it fixes:** The "Option 1: PR Comments" CI job fails when the PR is opened from a fork due to insufficient permissions at the point where the job attempts to create a commit on the PR (e.g., https://github.com/JuliaFirstOrder/ProximalOperators.jl/actions/runs/24360044045/job/71137029314#step:2:880). This might be fixed by repo settings, but this would weaken the security guards.