### PR TITLE
ci: allow fork checkout in pull_request_target benchmarks

### DIFF
--- a/.github/workflows/benchmark_pr_target.yml
+++ b/.github/workflows/benchmark_pr_target.yml
@@ -17,6 +17,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # This workflow intentionally benchmarks the PR's code (it needs the write
+          # token to comment on fork PRs), so it opts in to checking out fork head code
+          # under pull_request_target. actions/checkout@v6 refuses this by default; the
+          # composite action already runs the PR's code, so this re-accepts the existing
+          # (documented) risk rather than adding new exposure — see
+          # https://gh.io/securely-using-pull_request_target
+          allow-unsafe-pr-checkout: true
       - name: Run AirspeedVelocity composite action (local path)
         uses: ./                  # uses action.yml at the repo root
         with:

--- a/.github/workflows/benchmark_pr_target.yml
+++ b/.github/workflows/benchmark_pr_target.yml
@@ -17,12 +17,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          # This workflow intentionally benchmarks the PR's code (it needs the write
-          # token to comment on fork PRs), so it opts in to checking out fork head code
-          # under pull_request_target. actions/checkout@v6 refuses this by default; the
-          # composite action already runs the PR's code, so this re-accepts the existing
-          # (documented) risk rather than adding new exposure — see
-          # https://gh.io/securely-using-pull_request_target
+          # This workflow intentionally benchmarks fork PR code.
+          # Required by newer actions/checkout@v6 releases under pull_request_target.
           allow-unsafe-pr-checkout: true
       - name: Run AirspeedVelocity composite action (local path)
         uses: ./                  # uses action.yml at the repo root

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,7 @@ runs:
         persist-credentials: false  # Just for security considerations
         # This workflow intentionally benchmarks fork PR code.
         # Required by newer actions/checkout@v6 releases under pull_request_target.
+        allow-unsafe-pr-checkout: true
 
     - name: Setup Julia
       uses: julia-actions/setup-julia@v3

--- a/action.yml
+++ b/action.yml
@@ -25,13 +25,8 @@ runs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false  # Just for security considerations
-        # Needed when this composite action is invoked from a pull_request_target
-        # workflow (e.g. benchmark_pr_target.yml): actions/checkout@v6 otherwise refuses
-        # to check out fork head code in that trusted context. This action's job is to
-        # build and benchmark the PR's code, so it opts in. Under a plain pull_request
-        # workflow this input is a harmless no-op. See
-        # https://gh.io/securely-using-pull_request_target
-        allow-unsafe-pr-checkout: true
+        # This workflow intentionally benchmarks fork PR code.
+        # Required by newer actions/checkout@v6 releases under pull_request_target.
 
     - name: Setup Julia
       uses: julia-actions/setup-julia@v3

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,13 @@ runs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false  # Just for security considerations
+        # Needed when this composite action is invoked from a pull_request_target
+        # workflow (e.g. benchmark_pr_target.yml): actions/checkout@v6 otherwise refuses
+        # to check out fork head code in that trusted context. This action's job is to
+        # build and benchmark the PR's code, so it opts in. Under a plain pull_request
+        # workflow this input is a harmless no-op. See
+        # https://gh.io/securely-using-pull_request_target
+        allow-unsafe-pr-checkout: true
 
     - name: Setup Julia
       uses: julia-actions/setup-julia@v3


### PR DESCRIPTION
## Problem

`actions/checkout@v6` recently hardened its default to **refuse checking out fork PR head code under a `pull_request_target` workflow** (the classic "pwn request" vector). The `Benchmark PR with Comments` workflow (`benchmark_pr_target.yml`) checks out `github.event.pull_request.head.sha`, so it now fails at the checkout step for **every fork PR**:

```
##[error]Refusing to check out fork pull request code from a 'pull_request_target' workflow.
This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache
scope, and runner access. … To opt in … set 'allow-unsafe-pr-checkout: true' on the
actions/checkout step.
```

This shows up as red `bench (1)` / `bench (1.10)` checks on any PR from a fork (e.g. #133). The `pull_request` variant (`benchmark_pr.yml`) is unaffected; only the `pull_request_target` one hits the new refusal.

## Fix

Set `allow-unsafe-pr-checkout: true` on the two `actions/checkout@v6` steps that check out the PR head under `pull_request_target`:
- `benchmark_pr_target.yml` (the workflow's own checkout)
- `action.yml` (the composite action's checkout, reached from that workflow)

This workflow **intentionally** benchmarks the PR's code and holds `pull-requests: write` so it can comment on fork PRs — i.e. it already runs untrusted PR code in the trusted context by design. The flag re-accepts that pre-existing, documented risk rather than introducing new exposure ([securely using pull_request_target](https://gh.io/securely-using-pull_request_target)). Under a plain `pull_request` workflow the input is a harmless no-op.

A more defense-in-depth alternative would be to split the flow — run untrusted benchmarks under `pull_request` (no secrets) and post the comment from a separate trusted `workflow_run` — but that's a larger redesign; this restores the current design's behavior with a one-line-per-step change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)